### PR TITLE
Use only left ALT as meta key

### DIFF
--- a/src/winio.c
+++ b/src/winio.c
@@ -229,7 +229,7 @@ void read_keys_from(WINDOW *win)
 	curs_set(0);
 
 	/* Is either Alt key is down? */
-	if(GetAsyncKeyState(VK_MENU) < 0)
+	if(GetAsyncKeyState(VK_LMENU) < 0)
 		altdown = 1;
 
 	/* Initiate the keystroke buffer, and save the keycode in it. */
@@ -1111,7 +1111,7 @@ int parse_kbinput(WINDOW *win)
 		modifiers |= 0x01;
 	if(GetAsyncKeyState(VK_CONTROL) < 0)
 		modifiers |= 0x04;
-	if(GetAsyncKeyState(VK_MENU) < 0)
+	if(GetAsyncKeyState(VK_LMENU) < 0)
 		modifiers |= 0x08;
 	if (!mute_modifiers) {
 #ifndef NANO_TINY


### PR DESCRIPTION
Mapping both ALT keys as meta key causes issues getting certain special characters on international keyboards like German, were you need the right ALT/ALT GR key to get vital characters like @|~\{}[] etc. Restricting it to the left ALT key solves this issue.