### PR TITLE
Fix admin profile config and support APPDATA.

### DIFF
--- a/src/rcfile.c
+++ b/src/rcfile.c
@@ -1725,7 +1725,7 @@ void do_rcfiles(void)
 		parse_one_nanorc();
 
 	if (custom_nanorc == NULL) {
-		const char *xdgconfdir = getenv("XDG_CONFIG_HOME");
+		const char *xdgconfdir = getenv("APPDATA");
 
 		get_homedir();
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -36,9 +36,7 @@ void get_homedir(void)
 	if (homedir == NULL) {
 		const char *homenv = getenv("USERPROFILE");
 
-		/* When HOME isn't set, or when we're root, get the home directory
-		 * from the password file instead. */
-		if (homenv == NULL || IsUserAnAdmin())
+		if (homenv == NULL)
 			homenv = getenv("ALLUSERSPROFILE");
 
 		/* Only set homedir if some home directory could be determined,


### PR DESCRIPTION
Only use ALLUSERPROFILE for home dir when USERPROFILE is not set, even
for admin users.
Fix #34.

Also on Windows when looking for the rc, look in getenv("APPDATA")
instead of getenv("XDG_CONFIG_HOME"), which is mostly equivalent.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>